### PR TITLE
Upgrading build tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "underscore": "^1.8.3"
   },
   "devDependencies": {
-    "build-tools": "^1.5.2",
+    "build-tools": "^1.6.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "sinon": "^1.14.1"


### PR DESCRIPTION
Upgrading build tools to eliminate pesky mocha-phantomjs peerDependency error.
